### PR TITLE
jira-project-avatar-as-favicon: @match all paths

### DIFF
--- a/jira-project-avatar-as-favicon.user.js
+++ b/jira-project-avatar-as-favicon.user.js
@@ -1,12 +1,11 @@
 // ==UserScript==
 // @name         Jira: Project icon as tab icon
 // @namespace    http://tampermonkey.net/
-// @version      1
+// @version      2
 // @license      MIT
 // @description  Changes browser tab icon to JIRA project icon
 // @author       Sergey Lukashevich
-// @match        https://jira.example.com/browse/*
-// @match        https://jira.example.com/projects/*
+// @match        https://jira.example.com/*
 // @icon         https://jira.atlassian.com/favicon.ico
 // @homepageURL  https://github.com/rybak/atlassian-tweaks
 // @grant        none


### PR DESCRIPTION
In addition to `/browse/*` and `/projects/*`, avatars of Jira projects appear on other pages.  For example, "Project settings" and its subpages live under

    /plugins/servlet/project-config/

Let's just match all paths on the domain instead.  The script already checks for existence of needed elements before using them, so it will just do nothing on pages where project avatars don't exist.